### PR TITLE
Only prompt user for "fixing" .ssh/config if --nowait is not specif…

### DIFF
--- a/parsyncfp2
+++ b/parsyncfp2
@@ -3076,7 +3076,7 @@ sub fix_ssh_config () {
   } else {
     $append_fxt = 1;
   }
-  if ($append_fxt) {
+  if ($append_fxt && !$NOWAIT) {
     INFO(
       "parsyncfp2 would like to append 'ForwardX11Trusted yes' & 'ForwardX11 yes' 
         to your ~/.ssh/config.


### PR DESCRIPTION
…ied. Else this prompt prevents unattended use of parsyncfp2.

@hjmangalam I noticed while trying to script the use of parsyncfp2 that prompting the user to add `ForwardX11Trusted yes` to their `.ssh/config` is immune to `--nowait`. Though I don't know why, if I wrap parsyncfp2 in a bash script and use that script interactively (i.e. in a shell with a controlling terminal), the prompt is not printed. parsyncfp2 appears to hang until I press Enter, at which point the prompt to modify my .ssh/config is printed _and_ my .ssh/config is modified. One potential solution is what I propose in this PR, which is a modification of the fix_ssh_config subroutine making the prompting of the user conditional on `!$NOWAIT`.